### PR TITLE
Update version number to allow bump to work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "splitgill"
-version = "3.0.0-alpha"
+version = "3.0.0"
 description = "Versioned search library"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -70,7 +70,7 @@ exclude = ["tests", "docs"]
 
 [tool.commitizen]
 name = "cz_nhm"
-version = "2.0.0"
+version = "3.0.0"
 tag_format = "v$version"
 update_changelog_on_bump = true
 changelog_incremental = false


### PR DESCRIPTION
The versions didn't get bumped by the bump workflow and I think it's because the versions were wrong? Hopefully this fixes it.