### PR TITLE
Fix index op generation logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,4 @@ make-summary-multi-line = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/splitgill/indexing/index.py
+++ b/splitgill/indexing/index.py
@@ -1,14 +1,14 @@
 import abc
 import math
 from dataclasses import dataclass
-from typing import Optional, Iterable, Dict, NamedTuple
+from itertools import chain
+from typing import Any, Dict, Iterable, NamedTuple, Optional
 
-from orjson import dumps, OPT_NON_STR_KEYS
+from orjson import OPT_NON_STR_KEYS, dumps
 
 from splitgill.indexing.fields import DocumentField
-from splitgill.indexing.parser import parse
+from splitgill.indexing.parser import ParsedData, parse
 from splitgill.model import MongoRecord, ParsingOptions
-
 
 # the maximum number of documents to store in an arc index before creating a new one
 MAX_DOCS_PER_ARC = 2_000_000
@@ -121,6 +121,139 @@ class DeleteOp(BulkOp):
         return f'{{"delete":{{"_index":"{self.index}","_id":"{self.doc_id}"}}}}'
 
 
+@dataclass
+class RecordVersion:
+    """
+    A version of a record.
+
+    The version is valid until either the next version replaces it (referenced by the
+    next property) or it is deleted (represented by the deleted_at) property.
+    """
+
+    record_id: str
+    version: int
+    parsed: ParsedData
+    # pointer to the next RecordVersion
+    next: Optional["RecordVersion"] = None
+    # if this version has been deleted, this is set with the version it was deleted at
+    deleted_at: Optional[int] = None
+
+    @property
+    def version_end(self) -> Optional[int]:
+        """
+        Property which returns the version where this version becomes invalid. This
+        could be either the version it was deleted at, the version of the next version,
+        or if neither of these are set, None, implying there is no end to this version
+        and that this is the latest data for the record.
+
+        :return: a version or None
+        """
+        if self.deleted_at is not None:
+            return self.deleted_at
+        if self.next is not None:
+            return self.next.version
+        return None
+
+    def create_doc(self) -> dict:
+        """
+        Creates the document to be indexed in Elasticsearch for this version and returns
+        it.
+
+        :return: a dict document
+        """
+        doc = {
+            DocumentField.ID: self.record_id,
+            DocumentField.VERSION: self.version,
+            DocumentField.VERSIONS: {"gte": self.version},
+            DocumentField.DATA: self.parsed.parsed,
+            DocumentField.DATA_TYPES: self.parsed.data_types,
+            DocumentField.PARSED_TYPES: self.parsed.parsed_types,
+        }
+        if self.version_end is not None:
+            doc[DocumentField.NEXT] = self.version_end
+            doc[DocumentField.VERSIONS]["lt"] = self.version_end
+        return doc
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Determines if two record versions are equal. Two versions are deemed equal if
+        they have the same parsed data and this version doesn't represent a deleted
+        version.
+
+        :param other: any object
+        :return: True if the two record versions are equal, False if not, and returns
+            NotImplemented if the other parameter is not a RecordVersion
+        """
+        if isinstance(other, RecordVersion):
+            return self.deleted_at is None and other.parsed == self.parsed
+        return NotImplemented
+
+
+@dataclass
+class RecordVersions:
+    """
+    A linked list representing all the versions of the record that should be included in
+    Elasticsearch.
+    """
+
+    head: RecordVersion
+    last: RecordVersion
+
+    @classmethod
+    def build(
+        cls, record: MongoRecord, all_options: Dict[int, ParsingOptions]
+    ) -> "RecordVersions":
+        """
+        Build a new RecordVersion object using the data in the given record and all the
+        available options.
+
+        :param record: the record
+        :param all_options: all available options with versions as keys
+        :return: a new RecordVersion object
+        """
+        all_data = dict(record.iter())
+        first_data_version = min(all_data)
+        versions = sorted(set(chain(all_options, all_data)))
+
+        # init the data and options with the first versions
+        data = all_data[min(all_data)]
+        options = all_options[min(all_options)]
+
+        record_versions = None
+        for version in versions:
+            # if the first options version is before the first data version we should
+            # ignore it - if there's no data then what are the options going to act on?
+            if version < first_data_version:
+                continue
+
+            data = all_data.get(version, data)
+            options = all_options.get(version, options)
+            if not data:
+                # only set the deleted_at if the version isn't already deleted
+                if record_versions.last.deleted_at is None:
+                    record_versions.last.deleted_at = version
+                continue
+
+            doc = RecordVersion(record.id, version, parse(data, options))
+
+            if not record_versions:
+                record_versions = RecordVersions(doc, doc)
+            elif doc != record_versions.last:
+                record_versions.last.next = doc
+                record_versions.last = doc
+
+        return record_versions
+
+    def __iter__(self) -> Iterable[RecordVersion]:
+        doc = self.head
+        while True:
+            yield doc
+            if doc.next:
+                doc = doc.next
+            else:
+                break
+
+
 def generate_index_ops(
     indices: IndexNames,
     arc_status: ArcStatus,
@@ -141,118 +274,45 @@ def generate_index_ops(
     changes on the same data can result in no index change if the options don't impact
     the data in question (e.g. a geo hint change but the data has no geo data).
 
-    The bulk ops are yielded in reverse version order for each record with the op on the
-    latest index coming first and then the other index's ops following.
+    The bulk ops are yielded in ascending version order for each record.
 
     :param indices: an IndexNames object for the database
     :param arc_status: the current arc status
     :param records: the records to update from
     :param after: the exclusive start version to produce index operations from, None if
-                  all versions should be indexed
+        all versions should be indexed
     :param all_options: dict of versions to ParsingOptions objects, this should be all
-                        parsing option versions, not just the ones that apply after the
-                        after parameter (if it's even provided)
+        parsing option versions, not just the ones that apply after the after parameter
+        (if it's even provided)
     :return: yields BulkOp objects
     """
-    # initialise these based off the ArcStatus we are provided
     arc_index, arc_count = arc_status
-    # pre-sort the options in reverse version order
-    sorted_options = [
-        (option_version, all_options[option_version])
-        for option_version in sorted(all_options, reverse=True)
-    ]
-    # cache the latest option version
-    latest_option_version = max(all_options)
-    # and cache the latest index name
     latest_index = indices.latest
     # if after is not provided, using -inf ensures that all versions will be yielded
     if after is None:
         after = -math.inf
 
     for record in records:
-        if record.version <= after and latest_option_version <= after:
-            # nothing to do for this record
-            continue
+        record_versions = RecordVersions.build(record, all_options)
 
-        # create an iter for the record data and the options, both of these go backwards
-        data_iter = iter(record.iter())
-        options_iter = iter(sorted_options)
-        # these iters have to have at least one element so this is safe
-        data_version, data = next(data_iter)
-        options_version, options = next(options_iter)
-        version = max(data_version, options_version)
-        next_version = None
-        last_parsed_data = None
+        for rv in record_versions:
+            # this is the latest version, just yield the appropriate op and carry on
+            if rv.version > after and rv.next is None and rv.deleted_at is None:
+                yield IndexOp(latest_index, record.id, rv.create_doc())
+                continue
 
-        while True:
-            if not data:
-                last_parsed_data = None
-                # this is a delete! If this is the latest version then we delete the
-                # record's document in the latest index, otherwise do nothing
-                if next_version is None:
-                    yield DeleteOp(latest_index, record.id)
-            else:
-                parsed_data = parse(data, options)
-                # only yield an op if there is a change. Every data version should
-                # trigger an op to be yielded, but options versions can result in the
-                # same parsed data if the underlying data was the same between the
-                # versions and the options change didn't impact any of fields present in
-                # the data (e.g. changing a float string format when there are no
-                # floats)
-                if parsed_data != last_parsed_data:
-                    last_parsed_data = parsed_data
-                    document = {
-                        DocumentField.ID: record.id,
-                        DocumentField.VERSION: version,
-                        DocumentField.VERSIONS: {"gte": version},
-                        DocumentField.DATA: parsed_data.parsed,
-                        DocumentField.DATA_TYPES: parsed_data.data_types,
-                        DocumentField.PARSED_TYPES: parsed_data.parsed_types,
-                    }
-                    if next_version is None:
-                        index_name = latest_index
-                        doc_id = record.id
-                    else:
-                        # set the doc's ID to None to force Elasticsearch to create it,
-                        # this is an ingestion speed optimisation
-                        doc_id = None
-
-                        # add some stuff to the document
-                        document[DocumentField.NEXT] = next_version
-                        document[DocumentField.VERSIONS]["lt"] = next_version
-
-                        # figure out which arc we need to put this document in
-                        if arc_count >= MAX_DOCS_PER_ARC:
-                            arc_index += 1
-                            arc_count = 0
-                        index_name = indices.get_arc(arc_index)
-                        arc_count += 1
-
-                    yield IndexOp(index_name, doc_id, document)
-
-            # update state variables
-            if version == data_version:
-                next_data_item = next(data_iter, None)
-                if next_data_item is None:
-                    # there's no more data left, break the loop
-                    break
+            if rv.version <= after:
+                if rv.version_end is not None and rv.version_end > after:
+                    # getting here means this version of the record is already in
+                    # Elasticsearch and was the previous latest version at last sync
+                    if rv.next is None:
+                        yield DeleteOp(latest_index, record.id)
                 else:
-                    data_version, data = next_data_item
-            if version == options_version:
-                # because you have to have an option version at <= the first data
-                # version, this is ok
-                options_version, options = next(
-                    options_iter, (options_version, options)
-                )
-            next_version = version
-            version = max(data_version, options_version)
+                    continue
 
-            # we've run out of data/options
-            if version == next_version:
-                break
-            # this looks a bit weird, but it's a sneaky way to ensure we correctly
-            # update the latest doc as well as then shunting the old latest doc into the
-            # other data indices. It's the same as checking if version <= after and then
-            # doing one more loop
-            if next_version <= after:
-                break
+            # figure out which arc we need to put this document in
+            if arc_count >= MAX_DOCS_PER_ARC:
+                arc_index += 1
+                arc_count = 0
+            arc_count += 1
+            yield IndexOp(indices.get_arc(arc_index), None, rv.create_doc())

--- a/splitgill/indexing/syncing.py
+++ b/splitgill/indexing/syncing.py
@@ -1,10 +1,10 @@
 import time
-from asyncio import Queue, run, sleep, create_task, gather, Task
+from asyncio import Queue, Task, create_task, gather, run, sleep
 from dataclasses import dataclass
-from typing import Iterable, List, Set, Tuple, Optional
+from typing import Iterable, List, Optional, Set, Tuple
 
-from elastic_transport import NodeConfig, ConnectionTimeout
-from elasticsearch import Elasticsearch, AsyncElasticsearch
+from elastic_transport import ConnectionTimeout, NodeConfig
+from elasticsearch import AsyncElasticsearch, Elasticsearch
 
 from splitgill.indexing.index import BulkOp
 from splitgill.utils import partition
@@ -100,9 +100,8 @@ def write_ops(
     Write the given iterable of bulk index operations to Elasticsearch.
 
     :param client: an Elasticsearch client, this isn't actually used as the processing
-                   is done asynchronously using the AsyncElasticsearch class, but we
-                   pull the hosts from this Elasticsearch client to create the
-                   AsyncElasticsearch object
+        is done asynchronously using the AsyncElasticsearch class, but we pull the hosts
+        from this Elasticsearch client to create the AsyncElasticsearch object
     :param op_stream: an iterable of BulkOp objects
     :param options: options determining how we do the bulk write
     :return: a WriteResult object
@@ -183,6 +182,8 @@ async def write_ops_async(
         for _ in workers:
             await task_queue.put(None)
         await task_queue.join()
+
+        check_for_errors(workers)
 
         # collect the worker results up and return
         worker_counts = await gather(*workers)


### PR DESCRIPTION
The specifics of this issue relate to a specific circumstance where between two versions of a record, an options change is made which doesn't impact the representation of the data at the earlier version. Due to a logic error in the index op generation function, this resulted in missing versions (specifically the newer version in this scenario) due to the ops being incorrectly generated. This has now been fixed in this commit by rewriting the index op generation function. Two specific parts of the rewrite are worth highlighting. Firsly, an effort has been made to make the code easier to read and reason about which is particularly useful given it's a fairly complex area of logic. Secondly, the original logic was very iterator heavy and traversed the record's versions backwards from newest to oldest. This was origianlly implemented as it matches the storage mechanism in mongo for the versions and as it was seen as being the most efficient way to do it. Not only did it save memory it also allowed us to easily stop at the point where the versions are already synced to Elasticsearch (the after parameter) and not generate more data than we need. In the new version, all versions are generated and stored in a linked list which makes reasoning much easier and generally ensures the code is readable. This does mean there is likely to be a small performance hit from this code, however, I haven't tested this and compared to the cost of sending the documents to Elasticsearch, it is likely insignificant. A linked list is used because it is a much more natural way of presenting the versions of the record than a normal list and it just worked when I conceptualised it that way instead of with several lists working in tandem with different index variables that were incremented and decremented accordingly. Tests have been added to check that the bug is fixed and all the other tests relating to index ops have been fixed to work with the new index op generation function (the primary difference being that it now generates ops in ascending version order, not descending).

Closes: #34